### PR TITLE
fix(nginx): correct server_name conflicts and redirect rules

### DIFF
--- a/etc/nginx/sites-available/admission-help.org.conf
+++ b/etc/nginx/sites-available/admission-help.org.conf
@@ -172,7 +172,7 @@ server {
     # Enable HTTP/2
     http2 on;
 
-    server_name .admission-help.org;
+    server_name www.admission-help.org;
 
     ssl_certificate /etc/ssl/cert.pem;
     ssl_certificate_key /etc/ssl/key.pem;
@@ -190,7 +190,7 @@ server {
 server {
     listen 80 reuseport;
     listen [::]:80 reuseport;
-    server_name .admission-help.org;
+    server_name admission-help.org www.admission-help.org;
 
     access_log /var/log/nginx/access.log cloudflare buffer=512k flush=1m;
     error_log /var/log/nginx/error.log warn;

--- a/etc/nginx/sites-available/galaxyfreedom.com.conf
+++ b/etc/nginx/sites-available/galaxyfreedom.com.conf
@@ -172,7 +172,7 @@ server {
     # Enable HTTP/2
     http2 on;
 
-    server_name .galaxyfreedom.com;
+    server_name galaxyfreedom.com;
 
     ssl_certificate /etc/ssl/galaxyfreedom.com.cert.pem;
     ssl_certificate_key /etc/ssl/galaxyfreedom.com.key.pem;
@@ -190,7 +190,7 @@ server {
 server {
     listen 80;
     listen [::]:80;
-    server_name .galaxyfreedom.com;
+    server_name galaxyfreedom.com www.galaxyfreedom.com;
 
     access_log /var/log/nginx/access.log cloudflare buffer=512k flush=1m;
     error_log /var/log/nginx/error.log warn;


### PR DESCRIPTION
- Change redirect block server_name from .admission-help.org to www.admission-help.org to resolve conflicting server name warning on port 443
- Fix HTTP redirect block to catch both bare and www domains for admission-help.org
- Fix galaxyfreedom.com redirect block server_name from www to bare domain to avoid self-redirect loop
- Fix HTTP redirect destination from galaxyfreedom.com to admission-help.org in admission-help.org config