### PR TITLE
fix(csp): remove deprecated block-all-mixed-content and add missing directives

### DIFF
--- a/etc/nginx/nginxconfig.io/security-headers.conf
+++ b/etc/nginx/nginxconfig.io/security-headers.conf
@@ -3,4 +3,4 @@ add_header X-Content-Type-Options    "nosniff" always;
 add_header X-Frame-Options           "SAMEORIGIN" always;
 add_header Referrer-Policy           "strict-origin-when-cross-origin" always;
 add_header Permissions-Policy        "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()" always;
-add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$request_id' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' wss://admission-help.org; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; block-all-mixed-content;" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$request_id' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' wss://admission-help.org; frame-ancestors 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;" always;

--- a/etc/nginx/nginxconfig.io/security-headers.galaxyfreedom.com.conf
+++ b/etc/nginx/nginxconfig.io/security-headers.galaxyfreedom.com.conf
@@ -3,4 +3,4 @@ add_header X-Content-Type-Options    "nosniff" always;
 add_header X-Frame-Options           "SAMEORIGIN" always;
 add_header Referrer-Policy           "strict-origin-when-cross-origin" always;
 add_header Permissions-Policy        "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()" always;
-add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$request_id' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' wss://www.galaxyfreedom.com wss://galaxyfreedom.com; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; block-all-mixed-content;" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'nonce-$request_id' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' wss://galaxyfreedom.com; frame-ancestors 'self'; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;" always;


### PR DESCRIPTION
- Remove deprecated block-all-mixed-content directive
- Add frame-src 'none' to prevent the site from embedding external iframes
- Add object-src 'none' to block legacy plugin elements (Flash, Java applets)