### PR TITLE
fix: replace stale blob URLs with persistent server preview URLs after file upload

### DIFF
--- a/src/contexts/FileData/FileDataContext.tsx
+++ b/src/contexts/FileData/FileDataContext.tsx
@@ -6,6 +6,7 @@ export type SemesterKey = 0 | 1; // 0 for semester 1, 1 for semester 2
 export interface FileEntry {
   file: File | null;
   previewUrl: string | null;
+  serverPreviewUrl: string | null;
 }
 
 export interface FileData {
@@ -37,6 +38,11 @@ export interface FileDataContextType {
   clearEighthFormFiles: () => void;
   resetFileData: () => void;
   getFileDataForApi: () => FormData; // FormData for API submission
+  updateEighthFormServerUrl: (
+    grade: GradeKey,
+    semesterIndex: SemesterKey,
+    serverPreviewUrl: string,
+  ) => void;
 }
 
 export const FileDataContext = createContext<FileDataContextType | undefined>(
@@ -47,16 +53,16 @@ export const initialFileData: FileData = {
   eighthForm: {
     files: {
       "10": [
-        { file: null, previewUrl: null }, // Semester 1
-        { file: null, previewUrl: null }, // Semester 2
+        { file: null, previewUrl: null, serverPreviewUrl: null },
+        { file: null, previewUrl: null, serverPreviewUrl: null },
       ],
       "11": [
-        { file: null, previewUrl: null }, // Semester 1
-        { file: null, previewUrl: null }, // Semester 2
+        { file: null, previewUrl: null, serverPreviewUrl: null },
+        { file: null, previewUrl: null, serverPreviewUrl: null },
       ],
       "12": [
-        { file: null, previewUrl: null }, // Semester 1
-        { file: null, previewUrl: null }, // Semester 2
+        { file: null, previewUrl: null, serverPreviewUrl: null },
+        { file: null, previewUrl: null, serverPreviewUrl: null },
       ],
     },
   },

--- a/src/contexts/FileData/FileDataProvider.tsx
+++ b/src/contexts/FileData/FileDataProvider.tsx
@@ -168,6 +168,7 @@ export function FileDataProvider({ children }: { children: ReactNode }) {
         newFileData.eighthForm.files[grade][semesterIndex] = {
           file,
           previewUrl,
+          serverPreviewUrl: null,
         };
 
         return newFileData;
@@ -187,9 +188,29 @@ export function FileDataProvider({ children }: { children: ReactNode }) {
   // Get a specific preview URL
   const getEighthFormPreviewUrl = useCallback(
     (grade: GradeKey, semesterIndex: SemesterKey): string | null => {
-      return fileData.eighthForm.files[grade][semesterIndex].previewUrl;
+      const entry = fileData.eighthForm.files[grade][semesterIndex];
+      // Prefer server URL (persistent) over blob URL (temporary)
+      if (entry.serverPreviewUrl) {
+        return `${import.meta.env.VITE_API_BASE_URL}${entry.serverPreviewUrl}`;
+      }
+      return entry.previewUrl;
     },
     [fileData],
+  );
+
+  // Update server preview URL after successful upload
+  const updateEighthFormServerUrl = useCallback(
+    (grade: GradeKey, semesterIndex: SemesterKey, serverPreviewUrl: string) => {
+      setFileData((prev) => {
+        const newFileData = { ...prev };
+        newFileData.eighthForm.files[grade][semesterIndex] = {
+          ...newFileData.eighthForm.files[grade][semesterIndex],
+          serverPreviewUrl,
+        };
+        return newFileData;
+      });
+    },
+    [],
   );
 
   // Get all uploaded files for API submission
@@ -303,6 +324,7 @@ export function FileDataProvider({ children }: { children: ReactNode }) {
       resetFileData,
       getFileDataForApi,
       getRemainingTime,
+      updateEighthFormServerUrl,
     }),
     [
       fileData,
@@ -314,6 +336,7 @@ export function FileDataProvider({ children }: { children: ReactNode }) {
       resetFileData,
       getFileDataForApi,
       getRemainingTime,
+      updateEighthFormServerUrl,
     ],
   );
 

--- a/src/hooks/userProfile/useStudentProfile.ts
+++ b/src/hooks/userProfile/useStudentProfile.ts
@@ -19,7 +19,10 @@ import type { ErrorDetails } from "../../type/interface/error.details";
 import type { OcrResponse } from "../../type/interface/ocrTypes";
 import APIError from "../../utils/apiError";
 import { saveStudentId } from "../../utils/sessionManager";
-
+import type {
+  GradeKey,
+  SemesterKey,
+} from "../../contexts/FileData/FileDataContext";
 interface RetryProgress {
   attempt: number;
   maxAttempts: number;
@@ -39,7 +42,7 @@ export function useStudentProfile(): UseStudentProfileReturn {
   const navigate = useNavigate();
   const { t } = useTranslation();
   const { getFormDataForApi } = useFormData();
-  const { getAllEighthFormFiles, clearEighthFormFiles } = useFileData();
+  const { getAllEighthFormFiles, updateEighthFormServerUrl } = useFileData();
   const { processOcr, isOcrSuccessful } = useOcrHandler();
   const { clearAllData } = useNinthForm();
 
@@ -78,6 +81,17 @@ export function useStudentProfile(): UseStudentProfileReturn {
 
       if (isUploadSuccessful(response)) {
         setProcessingStatus(t("studentProfile.status.filesUploaded"));
+
+        response.data?.uploadedFiles?.forEach(
+          ({ grade, semester, previewUrl }) => {
+            const semesterIndex = (parseInt(semester) - 1) as SemesterKey;
+            updateEighthFormServerUrl(
+              grade as GradeKey,
+              semesterIndex,
+              previewUrl,
+            );
+          },
+        );
       } else {
         console.warn("[useStudentProfile] File upload issues:", statusMessage);
       }
@@ -191,12 +205,6 @@ export function useStudentProfile(): UseStudentProfileReturn {
           setUploadProgress(90);
         } else {
           setUploadProgress(90);
-        }
-
-        // Step 4: Cleanup
-        if (isUploadSuccessful(fileUploadResponse)) {
-          clearEighthFormFiles();
-          setProcessingStatus(t("studentProfile.status.cleaningUp"));
         }
 
         setUploadProgress(100);

--- a/src/type/interface/fileUploadTypes.ts
+++ b/src/type/interface/fileUploadTypes.ts
@@ -6,6 +6,7 @@ export interface FileUploadResponse {
     uploadedFiles?: {
       fileName: string;
       fileUrl: string;
+      previewUrl: string;
       grade: string;
       semester: string;
     }[];


### PR DESCRIPTION
- Add serverPreviewUrl field to FileEntry in FileDataContext
- Add updateEighthFormServerUrl method to FileDataProvider
- Update getEighthFormPreviewUrl to prefer server URL over blob URL
- Add previewUrl to FileUploadResponse type
- Call updateEighthFormServerUrl after successful upload in useStudentProfile
- Remove premature clearEighthFormFiles() call before navigation